### PR TITLE
Added viman script. Makes searching man pages easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 * `ctermlist`; print out your terminal emulator's supported colours
 
+* `viman`; launch manual pages with Vim
+
 * `launch_minecraft`; launch Minecraft (via minecraft-launcher-cmd) with ease and security
 
 ### Install scripts

--- a/viman
+++ b/viman
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Script to open man pages in vim, because vim is easier to find certain options than less
+# How it works: Running `viman sh` for example, would copy the sh man page to ~/.local/share/viman/sh and open it with vim.
+# Running `viman sh` in the future would open ~/.local/share/viman/sh in vim.
+# Pronounced 'vee eye man'
+
+VIMAN_MAN_LOCATION="$HOME/.local/share/viman"
+
+cd $VIMAN_MAN_LOCATION
+man $1 >> $1
+nvim $1
+# ^^ Change editor if you want


### PR DESCRIPTION
Running `viman sh` would copy the manual page for `sh` and put it into (by default) `$HOME/.local/share/viman/sh`. This can be done with any command with a man page.

By default, `viman` uses Neovim. This can be changed, of course.